### PR TITLE
dataservice,server: fix price conversions

### DIFF
--- a/api/dataservice/dataservice.go
+++ b/api/dataservice/dataservice.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"api/model"
-	
+
 	_ "github.com/mattn/go-sqlite3"
 	log "github.com/sirupsen/logrus"
 )
@@ -16,13 +16,13 @@ var sqldb *sql.DB
 
 // Initializes the pricing tool database
 func DBInit() {
-	
+
 	database, err := sql.Open("sqlite3", dbFilePath)
 	if err != nil {
 		log.Fatalln("Error in creating DB", err.Error())
 	}
 	sqldb = database
-	
+
 	statement, err := database.Prepare(`
 		CREATE TABLE IF NOT EXISTS Orchestrators (
 			Address TEXT PRIMARY KEY, 
@@ -35,45 +35,45 @@ func DBInit() {
 			DeactivationRound TEXT, 
 			Active INTEGER, 
 			Status TEXT, 
-			PricePerPixel INTEGER, 
+			PricePerPixel STRING, 
 			UpdatedAt INTEGER
 		)
 	`)
-	if err!=nil {
+	if err != nil {
 		log.Fatalln("Error in creating DB", err.Error())
 	}
 	_, err = statement.Exec()
-	if err!=nil {
+	if err != nil {
 		log.Fatalln("Error in creating DB", err.Error())
 	}
-	
+
 	statement, err = database.Prepare(`
 		CREATE TABLE IF NOT EXISTS PriceHistory (
 			Address TEXT, 
 			Time INTEGER, 
-			PricePerPixel INTEGER
+			PricePerPixel STRING
 		)
 	`)
-	if err!=nil {
+	if err != nil {
 		log.Fatalln("Error in creating DB", err.Error())
 	}
 	_, err = statement.Exec()
-	if err!=nil {
+	if err != nil {
 		log.Fatalln("Error in creating DB", err.Error())
 	}
-	
+
 	log.Info("DB created successfully.")
 }
 
 // Adds orchestrator statistics to the database
 func InsertOrchestrator(x model.Orchestrator) {
 	statement, err := sqldb.Prepare("INSERT INTO Orchestrators (Address, ServiceURI, LastRewardRound, RewardCut, FeeShare, DelegatedState, ActivationRound, DeactivationRound, Active, Status, PricePerPixel, UpdatedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
-	if err!=nil {
+	if err != nil {
 		log.Errorln("Error in inserting orchestrator", x.Address)
 		log.Errorln(err.Error())
 	}
 	_, err = statement.Exec(x.Address, x.ServiceURI, x.LastRewardRound, x.RewardCut, x.FeeShare, x.DelegatedStake.String(), x.ActivationRound, x.DeactivationRound.String(), x.Active, x.Status, x.PricePerPixel, time.Now().Unix())
-	if err!=nil {
+	if err != nil {
 		log.Errorln("Error in inserting orchestrator", x.Address)
 		log.Errorln(err.Error())
 	}
@@ -82,7 +82,7 @@ func InsertOrchestrator(x model.Orchestrator) {
 // Updates orchestrator statistics in the database
 func UpdateOrchestrator(x model.Orchestrator) {
 	statement, err := sqldb.Prepare("UPDATE Orchestrators SET ServiceURI=?, LastRewardRound=?, RewardCut=?, FeeShare=?, DelegatedState=?, ActivationRound=?, DeactivationRound=?, Active=?, Status=?, PricePerPixel=?, UpdatedAt=? WHERE Address=?")
-	if err!=nil {
+	if err != nil {
 		log.Errorln("Error in updating orchestrator", x.Address)
 		log.Errorln(err.Error())
 	}
@@ -96,7 +96,7 @@ func UpdateOrchestrator(x model.Orchestrator) {
 // Add price history to the database
 func InsertPriceHistory(x model.Orchestrator) {
 	statement, err := sqldb.Prepare("INSERT INTO PriceHistory (Address, Time, PricePerPixel) VALUES (?, ?, ?)")
-	if err!=nil {
+	if err != nil {
 		log.Errorln("Error in inserting price history", x.Address)
 		log.Errorln(err.Error())
 	}
@@ -108,7 +108,7 @@ func InsertPriceHistory(x model.Orchestrator) {
 }
 
 // Fetching orchestrator statistics
-func FetchOrchestratorStatistics(excludeUnavailable bool) ([]model.DBOrchestrator) {
+func FetchOrchestratorStatistics(excludeUnavailable bool) []model.DBOrchestrator {
 
 	rows, err := sqldb.Query("SELECT * FROM Orchestrators")
 	if err != nil {
@@ -119,7 +119,7 @@ func FetchOrchestratorStatistics(excludeUnavailable bool) ([]model.DBOrchestrato
 	x := model.DBOrchestrator{}
 	for rows.Next() {
 		rows.Scan(&x.Address, &x.ServiceURI, &x.LastRewardRound, &x.RewardCut, &x.FeeShare, &x.DelegatedStake, &x.ActivationRound, &x.DeactivationRound, &x.Active, &x.Status, &x.PricePerPixel, &x.UpdatedAt)
-		if excludeUnavailable==true && x.PricePerPixel=="0" {
+		if excludeUnavailable == true && x.PricePerPixel == "0" {
 			continue
 		}
 		orchestrators = append(orchestrators, x)
@@ -128,7 +128,7 @@ func FetchOrchestratorStatistics(excludeUnavailable bool) ([]model.DBOrchestrato
 }
 
 // Fetcing pricing history
-func FetchPricingHistory(address string) ([]model.DBPriceHistory) {
+func FetchPricingHistory(address string) []model.DBPriceHistory {
 
 	rows, err := sqldb.Query("SELECT * FROM PriceHistory WHERE Address=? ORDER BY Time DESC", address)
 	if err != nil {
@@ -145,7 +145,7 @@ func FetchPricingHistory(address string) ([]model.DBPriceHistory) {
 }
 
 // checking for existence of an orchestrator in table
-func IfOrchestratorExists(address string) (bool) {
+func IfOrchestratorExists(address string) bool {
 	count := 0
 	rows, err := sqldb.Query("SELECT * FROM Orchestrators WHERE Address=?", address)
 	if err != nil {
@@ -155,10 +155,9 @@ func IfOrchestratorExists(address string) (bool) {
 	for rows.Next() {
 		count += 1
 	}
-	if count==0 {
+	if count == 0 {
 		return false
 	} else {
 		return true
 	}
 }
-


### PR DESCRIPTION
This PR fixes price conversions the problem was two-fold

- There could have been errors in the `reformatPPP` function , I didn't really check but I made it simpler but utilising the `math/big` package and `big.Rat`. It's convenient in this sense that this API is written in go, because the price per pixel string being fetched from the broadcaster node is actually `big.Rat.String` so all we have to do to convert it into `float64` is set that string on an empty initialised `big.Rat` and take the float. 

Edit: the issue here was that the numerator and denominator were converted to `int64` but a `big.Rat` is a fraction of `big.Int` so this could have led to overflows. 

- The `big.Rat.String` price value returned from the broadcaster node was stored as an INTEGER. 

__________

Some additional feedback out of scope of this PR. 

- Instead of doing price conversions when fetching data from the DB, consider doing the conversion upon insertion/updating 

- Consider using an UPSERT statement instead of `insert` , `update` and `if exists` , [here's](https://github.com/livepeer/go-livepeer/blob/d9ea3358e0a43f07a0fd78880f37bd48750c1be2/common/db.go#L200) an example 

- The insertion and update statements in the DB take in an `model.Orchestrator` but the `fetch`    function returns a `model.DBOrchestrator` , since there is minimal difference between these types I feel like we can unify these and do the necessary conversion within the database API methods. 

- Return errors more often instead of logging them, while logging is fine for an MVP it's likely that for an end result more control over the flow is needed (I added an example as a TODO comment)

- Consider using the vscode golang tools which includes auto-lint on save and other cool features. 

- Consider using startup flags such as `-broadcaster` to connect to a broadcaster node at a specified URL at startup, as well as on which port to run the server, the path to host the DB at (this would be needed to containerise this and persist the DB outside of the container), ... 

Fixes #12 